### PR TITLE
Exclude users by Tag name or ID

### DIFF
--- a/.github/workflows/omero_plugin.yml
+++ b/.github/workflows/omero_plugin.yml
@@ -23,7 +23,7 @@ jobs:
     env:
       STAGE: cli
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Checkout omero-test-infra
         uses: actions/checkout@master
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
       - id: seed-isort-config
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         args: ["--profile", "black"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
       - id: seed-isort-config
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
+    rev: 5.11.5
     hooks:
       - id: isort
         args: ["--profile", "black"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
         args: ["--profile", "black"]
 
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
         args: [--target-version=py36]

--- a/README.rst
+++ b/README.rst
@@ -15,6 +15,22 @@ system without running the deletion::
 
     $ omero demo-cleanup --gigabytes 300
 
+To ignore users who's data whose data must not be deleted, you can Tag those users
+and specify the `Tag` or parent `Tag Group` by `Name` or `ID`.
+This is enabled by default using a Tag named "NO DELETE".
+So it is preferable to Tag users on the server with a `Tag` named "NO DELETE" or create
+a `Tag Group` named "NO DELETE" containing Tags linked to users.
+
+    # Add a Tag to a User via CLI (not possible to see this in the clients)
+    $ omero obj new ExperimenterAnnotationLink child=TagAnnotation:123 parent=Experimenter:52
+
+    # Choose a non-default Tag or Tag Group (by ID or Name) to ignore the tagged users
+    $ omero demo-cleanup --gigabytes 300 --ignore-tag "Tag Name"
+
+You can also specify individual users by ID or user name, e.g:
+
+    --ignore-users 123,user-1,ben,234
+
 To generate the list of users which data must be deleted to free 300GB on the
 system and running the deletion (WARNING: data belonging to these users will
 be removed permanently)::

--- a/src/omero_demo_cleanup/cli.py
+++ b/src/omero_demo_cleanup/cli.py
@@ -29,6 +29,7 @@ from omero_demo_cleanup.library import (
     choose_users,
     delete_data,
     resource_usage,
+    users_by_id_or_username,
     users_by_tag,
 )
 
@@ -96,6 +97,10 @@ class DemoCleanupControl(BaseControl):
             default="NO DELETE",
             help="Members tagged with this Tag (Name or ID) or child Tags are ignored.",
         )
+        parser.add_argument(
+            "--ignore-users",
+            help="Ingore users: Comma-separated IDs and/or user-names.",
+        )
         parser.set_defaults(func=self.cleanup)
 
     @gateway_required
@@ -122,6 +127,7 @@ class DemoCleanupControl(BaseControl):
                 )
 
             ignore = users_by_tag(self.gateway, args.ignore_tag)
+            ignore.extend(users_by_id_or_username(self.gateway, args.ignore_users))
             stats = resource_usage(
                 self.gateway, minimum_days=args.days, ignore_users=ignore
             )

--- a/src/omero_demo_cleanup/cli.py
+++ b/src/omero_demo_cleanup/cli.py
@@ -91,9 +91,10 @@ class DemoCleanupControl(BaseControl):
             " Default: false.",
         )
         parser.add_argument(
-            "--exclude-tag",
-            "-e",
-            help="Members tagged with Tag (Name or ID) are excluded from cleanup.",
+            "--ignore-tag",
+            "-t",
+            default="NO DELETE",
+            help="Members tagged with this Tag (Name or ID) or child Tags are ignored.",
         )
         parser.set_defaults(func=self.cleanup)
 
@@ -120,9 +121,9 @@ class DemoCleanupControl(BaseControl):
                     )
                 )
 
-            exclude = users_by_tag(self.gateway, args.exclude_tag)
+            ignore = users_by_tag(self.gateway, args.ignore_tag)
             stats = resource_usage(
-                self.gateway, minimum_days=args.days, exclude_users=exclude
+                self.gateway, minimum_days=args.days, ignore_users=ignore
             )
             users = choose_users(args.inodes, args.gigabytes * 1000**3, stats)
             self.ctx.err(f"Found {len(users)} user(s) for deletion.")

--- a/src/omero_demo_cleanup/cli.py
+++ b/src/omero_demo_cleanup/cli.py
@@ -29,7 +29,7 @@ from omero_demo_cleanup.library import (
     choose_users,
     delete_data,
     resource_usage,
-    users_by_group,
+    users_by_tag,
 )
 
 HELP = """Cleanup disk space on OMERO.server """
@@ -91,9 +91,9 @@ class DemoCleanupControl(BaseControl):
             " Default: false.",
         )
         parser.add_argument(
-            "--exclude-group",
+            "--exclude-tag",
             "-e",
-            help="Members of this group (Name or ID) are excluded from cleanup.",
+            help="Members tagged with Tag (Name or ID) are excluded from cleanup.",
         )
         parser.set_defaults(func=self.cleanup)
 
@@ -120,7 +120,7 @@ class DemoCleanupControl(BaseControl):
                     )
                 )
 
-            exclude = users_by_group(self.gateway, args.exclude_group)
+            exclude = users_by_tag(self.gateway, args.exclude_tag)
             stats = resource_usage(
                 self.gateway, minimum_days=args.days, exclude_users=exclude
             )

--- a/src/omero_demo_cleanup/cli.py
+++ b/src/omero_demo_cleanup/cli.py
@@ -25,7 +25,12 @@ from typing import Any, Callable
 
 from omero.cli import BaseControl, Parser
 from omero.gateway import BlitzGateway
-from omero_demo_cleanup.library import choose_users, delete_data, resource_usage, users_by_group
+from omero_demo_cleanup.library import (
+    choose_users,
+    delete_data,
+    resource_usage,
+    users_by_group,
+)
 
 HELP = """Cleanup disk space on OMERO.server """
 
@@ -94,7 +99,6 @@ class DemoCleanupControl(BaseControl):
 
     @gateway_required
     def cleanup(self, args: argparse.Namespace) -> None:
-
         if args.inodes == 0 and args.gigabytes == 0:
             self.ctx.die(23, "Please specify how much to delete")
 
@@ -117,7 +121,9 @@ class DemoCleanupControl(BaseControl):
                 )
 
             exclude = users_by_group(self.gateway, args.exclude_group)
-            stats = resource_usage(self.gateway, minimum_days=args.days, exclude_users=exclude)
+            stats = resource_usage(
+                self.gateway, minimum_days=args.days, exclude_users=exclude
+            )
             users = choose_users(args.inodes, args.gigabytes * 1000**3, stats)
             self.ctx.err(f"Found {len(users)} user(s) for deletion.")
             for user in users:

--- a/src/omero_demo_cleanup/library.py
+++ b/src/omero_demo_cleanup/library.py
@@ -182,8 +182,9 @@ def delete_data(conn: BlitzGateway, user_id: int, dry_run: bool = True) -> None:
 
 
 def exp_to_str(exp):
+    # "user-3" (#6) Charles Darwin
     full_name = f"{unwrap(exp.firstName)} {unwrap(exp.lastName)}"
-    return f"Experimenter:{exp.id.val} {full_name}"
+    return f'"{exp.omeName.val}" (#{exp.id.val}) {full_name}"'
 
 
 def users_by_id_or_username(conn: BlitzGateway, ignore_users: str) -> List[int]:

--- a/src/omero_demo_cleanup/library.py
+++ b/src/omero_demo_cleanup/library.py
@@ -198,8 +198,8 @@ def users_by_tag(conn: BlitzGateway, tag_name: str) -> List[int]:
         )
         for link in links:
             exp = link.parent
-            full_name = "%s %s" % (unwrap(exp.firstName), unwrap(exp.lastName))
-            print("  Experimenter:%s %s" % (exp.id.val, full_name))
+            full_name = f"{unwrap(exp.firstName)} {unwrap(exp.lastName)}"
+            print(f"  Experimenter:{exp.id.val} {full_name}")
     return exclude
 
 

--- a/src/omero_demo_cleanup/library.py
+++ b/src/omero_demo_cleanup/library.py
@@ -191,7 +191,7 @@ def users_by_group(conn: BlitzGateway, group_name: str) -> List[int]:
         if group is None:
             raise ValueError("Group: %s not found" % group_name)
         exclude = [gem.child.id.val for gem in group.copyGroupExperimenterMap()]
-        print("Excluding %s members of group: %s" % (len(exclude), group_name))
+        print("Excluding %s members of Group:%s %s" % (len(exclude), group.id, group.name))
     return exclude
 
 

--- a/src/omero_demo_cleanup/library.py
+++ b/src/omero_demo_cleanup/library.py
@@ -192,7 +192,10 @@ def users_by_tag(conn: BlitzGateway, tag_name: str) -> List[int]:
             raise ValueError("Tag: %s not found" % tag_name)
         links = conn.getAnnotationLinks("Experimenter", ann_ids=[tag.id])
         exclude = [link.child.id.val for link in links]
-        print("Excluding %s members linked to Tag:%s %s" % (len(exclude), tag.id, tag.textValue))
+        print(
+            "Excluding %s members linked to Tag:%s %s"
+            % (len(exclude), tag.id, tag.textValue)
+        )
     return exclude
 
 
@@ -252,14 +255,15 @@ def find_users(
 
 
 def resource_usage(
-        conn: BlitzGateway, minimum_days: int = 0, exclude_users:List[int] = []
-    ) -> List[UserStats]:
+    conn: BlitzGateway, minimum_days: int = 0, exclude_users: List[int] = []
+) -> List[UserStats]:
     # Note users' resource usage.
     # DiskUsage2.targetClasses remains too inefficient so iterate.
 
     user_stats = []
-    users, logouts = find_users(conn, minimum_days=minimum_days,
-                                exclude_users=exclude_users)
+    users, logouts = find_users(
+        conn, minimum_days=minimum_days, exclude_users=exclude_users
+    )
     for user_id, user_name in users.items():
         print(f'Finding disk usage of "{user_name}" (#{user_id}).')
         user = {"Experimenter": [user_id]}
@@ -305,7 +309,6 @@ def perform_delete(
 
 
 def main() -> None:
-
     with omero.cli.cli_login() as cli:
         conn = omero.gateway.BlitzGateway(client_obj=cli.get_client())
         try:

--- a/src/omero_demo_cleanup/library.py
+++ b/src/omero_demo_cleanup/library.py
@@ -184,7 +184,7 @@ def delete_data(conn: BlitzGateway, user_id: int, dry_run: bool = True) -> None:
 def exp_to_str(exp):
     # "user-3" (#6) Charles Darwin
     full_name = f"{unwrap(exp.firstName)} {unwrap(exp.lastName)}"
-    return f'"{exp.omeName.val}" (#{exp.id.val}) {full_name}"'
+    return f'"{exp.omeName.val}" (#{exp.id.val}) {full_name}'
 
 
 def users_by_id_or_username(conn: BlitzGateway, ignore_users: str) -> List[int]:

--- a/src/omero_demo_cleanup/library.py
+++ b/src/omero_demo_cleanup/library.py
@@ -181,17 +181,18 @@ def delete_data(conn: BlitzGateway, user_id: int, dry_run: bool = True) -> None:
         submit(conn, delete, Delete2Response)
 
 
-def users_by_group(conn: BlitzGateway, group_name: str) -> List[int]:
+def users_by_tag(conn: BlitzGateway, tag_name: str) -> List[int]:
     exclude = []
-    if group_name:
-        if group_name.isnumeric():
-            group = conn.getObject("ExperimenterGroup", group_name)
+    if tag_name:
+        if tag_name.isnumeric():
+            tag = conn.getObject("Annotation", tag_name)
         else:
-            group = conn.getObject("ExperimenterGroup", attributes={"name": group_name})
-        if group is None:
-            raise ValueError("Group: %s not found" % group_name)
-        exclude = [gem.child.id.val for gem in group.copyGroupExperimenterMap()]
-        print("Excluding %s members of Group:%s %s" % (len(exclude), group.id, group.name))
+            tag = conn.getObject("TagAnnotation", attributes={"textValue": tag_name})
+        if tag is None:
+            raise ValueError("Tag: %s not found" % tag_name)
+        links = conn.getAnnotationLinks("Experimenter", ann_ids=[tag.id])
+        exclude = [link.child.id.val for link in links]
+        print("Excluding %s members linked to Tag:%s %s" % (len(exclude), tag.id, tag.textValue))
     return exclude
 
 

--- a/src/omero_demo_cleanup/library.py
+++ b/src/omero_demo_cleanup/library.py
@@ -189,11 +189,13 @@ def users_by_tag(conn: BlitzGateway, tag_name: str) -> List[int]:
     if tag_name.isnumeric():
         tag = conn.getObject("Annotation", tag_name)
     else:
-        tags = list(conn.getObjects("TagAnnotation", attributes={"textValue": tag_name}))
+        tags = list(
+            conn.getObjects("TagAnnotation", attributes={"textValue": tag_name})
+        )
         tag = tags[0] if len(tags) > 0 else None
         if len(tags) > 1:
             ids = [tag.id for tag in tags]
-            raise ValueError("Multiple Tags with name: %s (%s)" % (tag_name, ids))
+            raise ValueError(f"Multiple Tags with name: {tag_name} ({ids})")
     if tag is None:
         raise ValueError("Tag: %s not found" % tag_name)
     # Check if this is a Tag Group

--- a/src/omero_demo_cleanup/library.py
+++ b/src/omero_demo_cleanup/library.py
@@ -186,7 +186,7 @@ def exp_to_str(exp):
     return f"Experimenter:{exp.id.val} {full_name}"
 
 
-def users_by_id_or_username(conn: BlitzGateway, ignore_users:str) -> List[int]:
+def users_by_id_or_username(conn: BlitzGateway, ignore_users: str) -> List[int]:
 
     if not ignore_users:
         return []


### PR DESCRIPTION
Fixes #8.
Use `--exclude-tag` with Tag ID or Name to exclude members linked to Tag from cleanup

e.g. testing on merge-ci
```
$ omero demo-cleanup --gigabytes 10 --exclude-tag blah
...
Ignoring users who have logged out within the past 0 days.
Aiming to delete at least 10 bytes of data.
Excluding 2 members linked to Tag:83076 blah
...
```

cc @pwalczysko @joshmoore 