### PR TITLE
Use conn.SERVICE_OPTS.setOmeroGroup(-1) at login

### DIFF
--- a/src/omero_demo_cleanup/cli.py
+++ b/src/omero_demo_cleanup/cli.py
@@ -47,6 +47,7 @@ def gateway_required(func: Callable) -> Callable:
     def _wrapper(self: Any, *args: Any, **kwargs: Any) -> Callable:
         self.client = self.ctx.conn(*args)
         self.gateway = BlitzGateway(client_obj=self.client)
+        self.gateway.SERVICE_OPTS.setOmeroGroup("-1")
 
         try:
             return func(self, *args, **kwargs)

--- a/src/omero_demo_cleanup/library.py
+++ b/src/omero_demo_cleanup/library.py
@@ -363,6 +363,7 @@ def perform_delete(
 def main() -> None:
     with omero.cli.cli_login() as cli:
         conn = omero.gateway.BlitzGateway(client_obj=cli.get_client())
+        conn.SERVICE_OPTS.setOmeroGroup("-1")
         try:
             perform_delete(conn)
         except KeyboardInterrupt:


### PR DESCRIPTION
This should fix the `ValueError: Tag: NO DELETE not found` that you get now if your default group is different from the group where that Tag is.

cc @pwalczysko @khaledk2 