### PR TITLE
Use the same testing and publishing framework as omero-figure

### DIFF
--- a/.github/workflows/omero_plugin.yml
+++ b/.github/workflows/omero_plugin.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   test:
     name: Run integration tests against OMERO
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       STAGE: cli
     steps:

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -5,18 +5,18 @@ on: push
 jobs:
   build-n-publish:
     name: Publish to PyPI
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.10'
       - name: Build a binary wheel and a source tarball
         run: |
           python -mpip install build
           python -m build
       - name: Publish distribution to PyPI
         if: startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@v1.8.14
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_PASSWORD }}


### PR DESCRIPTION
This is a trivial bump of the publishing and testing framework similar to https://github.com/ome/omero-figure/tree/master/.github/workflows.

The main purpose is to get the build green again, after the main culprit (https://github.com/ome/omero-demo-cleanup/pull/18) was closed.